### PR TITLE
Compiling on FreeBSD with Clang

### DIFF
--- a/src/Make_src.inc
+++ b/src/Make_src.inc
@@ -23,6 +23,13 @@ endif
 ifeq "$(shell uname -o)" "Cygwin"
 CFLAGS += -Wno-char-subscripts
 endif
+ifeq "$(shell uname -o)" "FreeBSD"
+CFLAGS += -Wno-non-literal-null-conversion
+CFLAGS += -Wno-parentheses-equality
+CFLAGS += -Wno-uninitialized
+CFLAGS += -Wno-empty-body
+CFLAGS += -Wno-format-security
+endif
 
 ifeq "$(origin DJGPP)" "undefined"
 


### PR DESCRIPTION
A bunch of warnings need to be suppressed for HuC to compile on FreeBSD using Clang. I guess this should apply to any OS that uses Clang, but I have no way to test.

Would it be worthwile to clean up the code that is giving the warnings? Or are changes like these apt to produce problems on other compilers?

Thanks for your continued work on HuC! (Also a big thanks to all the previous devs! ;))